### PR TITLE
Fix incompatibility with QT 5

### DIFF
--- a/datagui/package/ui/SummaryTab.py
+++ b/datagui/package/ui/SummaryTab.py
@@ -18,6 +18,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
 
 """
 
+import math
 from PyQt5.QtCore import QSize
 from PyQt5.QtCore import Qt
 from PyQt5.QtWidgets import QWidget, QSizePolicy, QGroupBox, QGridLayout, QHBoxLayout, QButtonGroup, QTextEdit, QLabel
@@ -67,7 +68,7 @@ class SummaryTab(QWidget):
         flags_group_box = QGroupBox("Rating")
         #icon_size = QSize(20, 20)
         font_size = QFontMetrics(self.user_comment.currentFont()).size(0,"A").height()
-        font_size *= 1.1
+        font_size = math.ceil(font_size * 1.1)
         icon_size = QSize(font_size, font_size)
         
         flag_0 = createIconButton(icon_size, LeakFlags.NOLEAK)


### PR DESCRIPTION
QT 5 declares ``QSize(int width, int height)`` and ``QSize()`` as the only
constructors for this type [1]. Currently, two float values are passed to the
constructor. Pass the mathematical ceiling instead  to satisfy the QT 5 type
requirements.

[1] https://doc.qt.io/qt-5/qsize.html

Runtime error for reference:
```
Traceback (most recent call last):
  File "/home/user/MEGA/Dokumente/Studium/Informatik/SCAD/DATA/data-gui/datagui/package/ui/MainWindow.py", line 1032, in leakClicked
    self.handleLeakSelection(leak)
  File "/home/user/MEGA/Dokumente/Studium/Informatik/SCAD/DATA/data-gui/datagui/package/ui/MainWindow.py", line 1299, in handleLeakSelection
    self.setupInfoBox(call_leak)
  File "/home/user/MEGA/Dokumente/Studium/Informatik/SCAD/DATA/data-gui/datagui/package/ui/MainWindow.py", line 1144, in setupInfoBox
    summary_widget = SummaryTab(leak, self.updateFlagIcon, self.notifyUnsavedChanges)
  File "/home/user/MEGA/Dokumente/Studium/Informatik/SCAD/DATA/data-gui/datagui/package/ui/SummaryTab.py", line 54, in __init__
    self.setupUI()
  File "/home/user/MEGA/Dokumente/Studium/Informatik/SCAD/DATA/data-gui/datagui/package/ui/SummaryTab.py", line 71, in setupUI
    icon_size = QSize(font_size, font_size)
TypeError: arguments did not match any overloaded call:
  QSize(): too many arguments
  QSize(int, int): argument 1 has unexpected type 'float'
  QSize(QSize): argument 1 has unexpected type 'float'
```